### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_product, only: [:edit, :show, :update]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :set_product, only: [:edit, :show, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @products = Product.all.order("created_at DESC")
@@ -34,6 +34,12 @@ class ProductsController < ApplicationController
     end
   end
 
+  def destroy
+    @product.destroy
+    redirect_to root_path
+  end
+
+
 
   private
 
@@ -48,6 +54,6 @@ class ProductsController < ApplicationController
   def move_to_index
     unless @product.user_id == current_user.id
       redirect_to products_path
-    end
+    end 
   end
 end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @product.user_id%>
         <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", product_path(@product.id), method: :delete, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "products#index"
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products
 end


### PR DESCRIPTION
#What
商品削除機能の実装


#Why
商品を削除できるようするため


・ログイン状態の出品者のみ、出品した商品情報を削除できること」とは、詳細ページにおける「削除」ボタンの表示・非表示に加え、コントローラー側でも条件を設けることを指す。
https://i.gyazo.com/9f6614323eb3a2ccf5c8b4ff4f519912.gif

